### PR TITLE
Time component refactor

### DIFF
--- a/src/Time/index.js
+++ b/src/Time/index.js
@@ -1,58 +1,37 @@
-import React, {useEffect, useState, useRef} from 'react';
+import React, {useReducer, useRef} from 'react';
 import PropTypes from 'prop-types';
 
+import useInterval from '../useInterval';
 import {date, getDateString} from './getDateString';
 
+function useForceUpdate() {
+	const [, forceUpdate] = useReducer(e => e + 1, 0);
+	return forceUpdate;
+}
+
 function Time({dateTime, systemTime, locale}) {
+	const forceUpdate = useForceUpdate();
+
 	// Offset system time with local time...
 	const systemOffset = useRef(
 		date(systemTime) ? date(systemTime).getTime() - Date.now() : 0
 	);
 
 	// Get the date string and the delay before running the next loop
-	const [dateString, delayValue] = getDateString({
+	const [dateString, delay] = getDateString({
 		dateTime,
 		locale,
 		systemOffset: systemOffset.current,
 	});
 
-	// Set the current generated datestring
-	const [outputValue, setOutputValue] = useState(dateString);
-
-	// Set the current generated datestring
-	const [delay, setDelay] = useState(delayValue);
-
 	// Set the datestring
-	useEffect(() => {
-		let timer = null;
-
-		if (delay) {
-			timer = setInterval(() => {
-				// Get the date string and the delay before running the next loop
-				const [dateString, delayValue] = getDateString({
-					dateTime,
-					locale,
-					systemOffset: systemOffset.current,
-				});
-
-				// Set the output value...
-				setOutputValue(dateString);
-
-				// Set delay
-				setDelay(delayValue);
-			}, delay);
-		}
-
-		return () => {
-			clearInterval(timer);
-		};
-	});
+	useInterval(forceUpdate, delay);
 
 	const title = date(dateTime);
 
 	return (
 		<time dateTime={dateTime} title={title && title.toLocaleString()}>
-			{outputValue || 'n/a'}
+			{dateString || 'n/a'}
 		</time>
 	);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -19,3 +19,6 @@ export {default as Switch} from './Switch';
 export {default as Text} from './Text';
 export {default as TextLink} from './TextLink';
 export {default as ThemeSection} from './ThemeSection';
+export {default as Time} from './Time';
+export {default as useBreakpoints} from './useBreakpoints';
+export {default as useInterval} from './useInterval';

--- a/src/useInterval/README.mdx
+++ b/src/useInterval/README.mdx
@@ -7,7 +7,7 @@ import {Playground, Props} from 'docz';
 
 # useInterval
 
-A hook for safely & declarative setting up intervals in functional React components.
+A hook for safely & declaratively setting up intervals in functional React components.
 
 Based on Dan Abramov's blog post ["Making setInterval Declarative with React Hooks"](https://overreacted.io/making-setinterval-declarative-with-react-hooks/)
 

--- a/src/useInterval/README.mdx
+++ b/src/useInterval/README.mdx
@@ -1,0 +1,29 @@
+---
+name: useInterval
+menu: Hooks
+---
+
+import {Playground, Props} from 'docz';
+
+# useInterval
+
+A hook for safely & declarative setting up intervals in functional React components.
+
+Based on Dan Abramov's blog post ["Making setInterval Declarative with React Hooks"](https://overreacted.io/making-setinterval-declarative-with-react-hooks/)
+
+## Example
+
+```jsx
+import useInterval from 'base5-ui/useInterval';
+
+function Counter() {
+	const [count, setCount] = useState(0);
+
+	useInterval(() => {
+		// Your custom logic here
+		setCount(count + 1);
+	}, 1000);
+
+	return <h1>{count}</h1>;
+}
+```

--- a/src/useInterval/index.js
+++ b/src/useInterval/index.js
@@ -1,0 +1,28 @@
+import {useRef, useEffect} from 'react';
+
+/**
+ * @param {Function} callback - Function to run
+ * @param {number|null} delay - Delay in milliseconds. Interval pauses when null
+ */
+
+function useInterval(callback, delay) {
+	const savedCallback = useRef();
+
+	// Remember the latest callback.
+	useEffect(() => {
+		savedCallback.current = callback;
+	});
+
+	// Set up the interval.
+	useEffect(() => {
+		function tick() {
+			savedCallback.current();
+		}
+		if (delay !== null) {
+			const id = setInterval(tick, delay);
+			return () => clearInterval(id);
+		}
+	}, [delay]);
+}
+
+export default useInterval;

--- a/src/useInterval/index.js
+++ b/src/useInterval/index.js
@@ -2,7 +2,7 @@ import {useRef, useEffect} from 'react';
 
 /**
  * @param {Function} callback - Function to run
- * @param {number|null} delay - Delay in milliseconds. Interval pauses when null
+ * @param {number|null|undefined} delay - Delay in milliseconds. Interval pauses when null
  */
 
 function useInterval(callback, delay) {
@@ -18,7 +18,7 @@ function useInterval(callback, delay) {
 		function tick() {
 			savedCallback.current();
 		}
-		if (delay !== null) {
+		if (typeof delay === 'number') {
 			const id = setInterval(tick, delay);
 			return () => clearInterval(id);
 		}


### PR DESCRIPTION
- Adds new `useInterval` hook for use in the Time component - this makes `setInterval` declarative & more robust in React (see [this blog post](https://overreacted.io/making-setinterval-declarative-with-react-hooks/) about why this is needed)
- Simplify state management in Time component - we only need to force a rerender periodically, no need to copy the time and delay into state