### PR TITLE
chore(commit-message): enforces semantic commit messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
 		"@babel/plugin-proposal-object-rest-spread": "^7.6.2",
 		"@babel/plugin-transform-react-jsx": "^7.3.0",
 		"@babel/preset-env": "^7.6.3",
+		"@commitlint/cli": "^8.2.0",
+		"@commitlint/config-conventional": "^8.2.0",
 		"@semantic-release/changelog": "^3.0.5",
 		"@semantic-release/git": "^7.0.17",
 		"@testing-library/react": "^9.3.1",
@@ -50,14 +52,15 @@
 		"eslint-plugin-react": "^7.16.0",
 		"eslint-plugin-react-hooks": "^2.2.0",
 		"gh-pages": "^2.1.1",
+		"husky": "^3.1.0",
 		"jest": "23.1.0",
 		"jest-dom": "3.5.0",
 		"pixo": "^1.1.2",
 		"prettier": "^1.18.2",
 		"prop-types": "^15.7.2",
 		"react": "^16.11.0",
-		"react-dom": "^16.11.0",
 		"react-docgen-annotation-resolver": "^2.0.0",
+		"react-dom": "^16.11.0",
 		"semantic-release": "^15.13.12",
 		"styled-components": "^4.4.1"
 	},
@@ -74,6 +77,26 @@
 		"popper.js": "^1.16.0",
 		"react-hook-size": "^1.3.0",
 		"react-popper": "^1.3.6"
+	},
+	"commitlint": {
+		"extends": [
+			"@commitlint/config-conventional"
+		],
+		"rules": {
+			"subject-case": [
+				2,
+				"never",
+				[
+					"start-case",
+					"pascal-case"
+				]
+			]
+		}
+	},
+	"husky": {
+		"hooks": {
+			"commit-msg": "commitlint -E  HUSKY_GIT_PARAMS"
+		}
 	},
 	"release": {
 		"branch": "master",


### PR DESCRIPTION
@diondiondion  i noticed some of your commit messages sometimes aren't valid for semantic release e.g. ["Feat" instead of lowercase "feat"](https://github.com/5app/base5-ui/commit/3239dfa8911709de980d41d545726108c3261306)

Try this...

Insists on semantic commit messages

`npm i --save-dev @commitlint/cli @commitlint/config-conventional husky`

Read more here https://medium.com/@jsilvax/automate-semantic-versioning-with-conventional-commits-d76a9f45f2fa