### PR TITLE
feat: Responsive style props a la styled-system

### DIFF
--- a/src/Box/README.mdx
+++ b/src/Box/README.mdx
@@ -24,7 +24,7 @@ The following properties can be changed:
 	<Box border="bottom" pb="s">
 		Hello
 	</Box>
-	<Box bold mt="s" p="s">
+	<Box bold breakpoints="s" mt={['xs', 'l']} p="s">
 		Hello
 	</Box>
 </Playground>

--- a/src/Box/index.js
+++ b/src/Box/index.js
@@ -22,23 +22,53 @@ const Box = styled.div`
 `;
 
 Box.propTypes = {
-	position: PropTypes.oneOf(['static', 'relative', 'absolute', 'fixed']),
-	display: PropTypes.oneOf(['block', 'inline', 'inline-block']),
-	border: PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
-	flexAlign: PropTypes.oneOf(['top', 'left', 'center', 'bottom', 'right']),
-	basis: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-	grow: PropTypes.bool,
-	shrink: PropTypes.bool,
-	bold: PropTypes.bool,
+	position: PropTypes.oneOfType([
+		PropTypes.oneOf(['static', 'relative', 'absolute', 'fixed']),
+		PropTypes.array,
+	]),
+	display: PropTypes.oneOfType([
+		PropTypes.oneOf(['block', 'inline', 'inline-block']),
+		PropTypes.array,
+	]),
+	border: PropTypes.oneOfType([
+		PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
+		PropTypes.array,
+	]),
+	flexAlign: PropTypes.oneOfType([
+		PropTypes.oneOf(['top', 'left', 'center', 'bottom', 'right']),
+		PropTypes.array,
+	]),
+	basis: PropTypes.oneOfType([
+		PropTypes.number,
+		PropTypes.string,
+		PropTypes.array,
+	]),
+	grow: PropTypes.oneOfType([
+		PropTypes.bool,
+		PropTypes.number,
+		PropTypes.array,
+	]),
+	shrink: PropTypes.oneOfType([
+		PropTypes.bool,
+		PropTypes.number,
+		PropTypes.array,
+	]),
+	bold: PropTypes.oneOfType([PropTypes.bool, PropTypes.array]),
 	caps: PropTypes.oneOfType([
 		PropTypes.oneOf(['all', 'first']),
-		PropTypes.bool,
+		PropTypes.array,
 	]),
-	dimmed: PropTypes.bool,
-	fontSize: PropTypes.string,
-	lineHeight: PropTypes.number,
-	overflow: PropTypes.oneOf(['ellipsis', 'wrap']),
-	textAlign: PropTypes.oneOf(['left', 'center', 'right']),
+	dimmed: PropTypes.oneOfType([PropTypes.bool, PropTypes.array]),
+	fontSize: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
+	lineHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.array]),
+	overflow: PropTypes.oneOfType([
+		PropTypes.oneOf(['ellipsis', 'wrap']),
+		PropTypes.array,
+	]),
+	textAlign: PropTypes.oneOfType([
+		PropTypes.oneOf(['left', 'center', 'right']),
+		PropTypes.array,
+	]),
 };
 
 // @component

--- a/src/Text/README.mdx
+++ b/src/Text/README.mdx
@@ -36,7 +36,7 @@ In addition to the `fontSize` and `textAlign` props, this component also support
 	</Text>
 	<Text as="p" caps="first">
 		this text is all-lowercase, but is displayed in title-case{' '}
-		<Text caps={false}>(unless overwritten)</Text>
+		<Text caps="none">(unless overwritten)</Text>
 	</Text>
 	<Text as="p" overflow="wrap" mt="m">
 		OverflowWrapWillMakeLongWordsWithNoSpacesForExampleUrlsBreakIntoANewLineInsteadOfGoingOnAndBreakingOutOfTheirContainerWhichUsuallyDoesntLookVeryGood.

--- a/src/Text/index.js
+++ b/src/Text/index.js
@@ -21,17 +21,26 @@ const Text = styled.span`
 `;
 
 Text.propTypes = {
-	bold: PropTypes.bool,
+	bold: PropTypes.oneOfType([PropTypes.bool, PropTypes.array]),
 	caps: PropTypes.oneOfType([
 		PropTypes.oneOf(['all', 'first']),
-		PropTypes.bool,
+		PropTypes.array,
 	]),
-	dimmed: PropTypes.bool,
-	display: PropTypes.oneOf(['block', 'inline', 'inline-block']),
-	fontSize: PropTypes.string,
-	lineHeight: PropTypes.number,
-	overflow: PropTypes.oneOf(['ellipsis', 'wrap']),
-	textAlign: PropTypes.oneOf(['left', 'center', 'right']),
+	dimmed: PropTypes.oneOfType([PropTypes.bool, PropTypes.array]),
+	display: PropTypes.oneOfType([
+		PropTypes.oneOf(['block', 'inline', 'inline-block']),
+		PropTypes.array,
+	]),
+	fontSize: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
+	lineHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.array]),
+	overflow: PropTypes.oneOfType([
+		PropTypes.oneOf(['ellipsis', 'wrap']),
+		PropTypes.array,
+	]),
+	textAlign: PropTypes.oneOfType([
+		PropTypes.oneOf(['left', 'center', 'right']),
+		PropTypes.array,
+	]),
 };
 
 // @component

--- a/src/Text/index.js
+++ b/src/Text/index.js
@@ -23,7 +23,7 @@ const Text = styled.span`
 Text.propTypes = {
 	bold: PropTypes.oneOfType([PropTypes.bool, PropTypes.array]),
 	caps: PropTypes.oneOfType([
-		PropTypes.oneOf(['all', 'first']),
+		PropTypes.oneOf(['all', 'first', 'none']),
 		PropTypes.array,
 	]),
 	dimmed: PropTypes.oneOfType([PropTypes.bool, PropTypes.array]),

--- a/src/gatsby-theme-docz/wrapper.js
+++ b/src/gatsby-theme-docz/wrapper.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {createGlobalStyle} from 'styled-components';
+import styled, {createGlobalStyle} from 'styled-components';
 
 // These paths are relative to where this file goes after
 // docz moves it to .docz/src/gatsby-theme-docz/wrapper.js
@@ -27,13 +27,16 @@ const GlobalStyle = createGlobalStyle`
 	}
 `;
 
+const Content = styled.div`
+	font-size: ${p => p.theme.globals.typeScale.m};
+	line-height: ${p => p.theme.globals.lineHeight};
+`;
+
 const Wrapper = ({children}) => (
-	<>
+	<ThemeSection name="page" baseTheme={theme}>
 		<GlobalStyle />
-		<ThemeSection name="page" baseTheme={theme}>
-			{children}
-		</ThemeSection>
-	</>
+		<Content>{children}</Content>
+	</ThemeSection>
 );
 
 export default Wrapper;

--- a/src/mixins/ellipsis.js
+++ b/src/mixins/ellipsis.js
@@ -4,4 +4,9 @@ const ellipsis = {
 	whiteSpace: 'nowrap',
 };
 
+export const ellipsisReset = {
+	overflow: 'visible',
+	whiteSpace: 'normal',
+};
+
 export default ellipsis;

--- a/src/mixins/overflowWrap.js
+++ b/src/mixins/overflowWrap.js
@@ -5,4 +5,11 @@ const overflowWrap = {
 	wordBreak: 'break-word',
 };
 
+export const overflowWrapReset = {
+	overflowWrap: 'normal',
+	wordWrap: 'normal',
+
+	wordBreak: 'normal',
+};
+
 export default overflowWrap;

--- a/src/styleProps/borderProps.js
+++ b/src/styleProps/borderProps.js
@@ -1,5 +1,4 @@
-import {checkTheme} from '../utils/styleProps';
-
+import {createStyleFunction} from '../utils/styleProps';
 import {borderValue} from '../mixins';
 
 const borderKeys = {
@@ -9,18 +8,19 @@ const borderKeys = {
 	right: 'borderRight',
 };
 
-function borderProps(props) {
-	const {border, theme} = props;
-
-	checkTheme(theme);
-
-	if (!borderKeys[border]) {
-		return null;
-	}
-
-	return {
-		[borderKeys[border]]: borderValue(theme),
-	};
-}
+const borderProps = createStyleFunction([
+	{
+		styleProp: 'border',
+		getRules: (border, theme) => {
+			if (!borderKeys[border]) {
+				return null;
+			}
+			return {
+				border: 'none',
+				[borderKeys[border]]: borderValue(theme),
+			};
+		},
+	},
+]);
 
 export default borderProps;

--- a/src/styleProps/borderProps.js
+++ b/src/styleProps/borderProps.js
@@ -1,4 +1,4 @@
-import {checkTheme} from '../utils/theme';
+import {checkTheme} from '../utils/styleProps';
 
 import {borderValue} from '../mixins';
 

--- a/src/styleProps/displayProps.js
+++ b/src/styleProps/displayProps.js
@@ -1,21 +1,20 @@
+import {createStyleFunction} from '../utils/styleProps';
+
 const supportedDisplayValues = ['block', 'inline', 'inline-block'];
 
-function displayProps(props) {
-	const {display} = props;
-
-	if (!display) return null;
-
-	if (supportedDisplayValues.includes(display)) {
-		return {
-			display,
-		};
-	} else {
-		console.warn(
-			`Only 'block', 'inline', and 'inline-block' are supported for
+const displayProps = createStyleFunction([
+	{
+		styleProp: 'display',
+		properties: ['display'],
+		getValue: display =>
+			supportedDisplayValues.includes(display)
+				? display
+				: console.warn(
+						`Only 'block', 'inline', and 'inline-block' are supported for
 			the 'display' styling prop. Please use 'base5-ui/Flex' or custom CSS
 			for more complex styling.`
-		);
-	}
-}
+				  ),
+	},
+]);
 
 export default displayProps;

--- a/src/styleProps/flexProps.js
+++ b/src/styleProps/flexProps.js
@@ -1,3 +1,4 @@
+import {createStyleFunction} from '../utils/styleProps';
 import {pxToRem} from '../utils/units';
 
 export const alignMap = {
@@ -8,19 +9,37 @@ export const alignMap = {
 	right: 'flex-end',
 };
 
-function flexProps(props) {
-	const {flexAlign, basis, grow, shrink} = props;
+const baseRules = {
+	/* Reset flex to */
+	flex: 'none',
+	/* Prevent overflowing content from expanding flex items */
+	minWidth: 0,
+};
 
-	return {
-		/* Reset flex to */
-		flex: 'none',
-		/* Prevent overflowing content from expanding flex items */
-		minWidth: 0,
-		flexBasis: basis ? pxToRem(basis) : undefined,
-		flexGrow: grow ? 1 : undefined,
-		flexShrink: shrink ? 1 : undefined,
-		alignSelf: alignMap[flexAlign] || flexAlign,
-	};
-}
+const flexProps = createStyleFunction(
+	[
+		{
+			styleProp: 'basis',
+			properties: ['flexBasis'],
+			getValue: pxToRem,
+		},
+		{
+			styleProp: 'grow',
+			properties: ['flexGrow'],
+			getValue: value => Number(value),
+		},
+		{
+			styleProp: 'shrink',
+			properties: ['flexShrink'],
+			getValue: value => Number(value),
+		},
+		{
+			styleProp: 'flexAlign',
+			properties: ['alignSelf'],
+			getValue: value => alignMap[value] || value,
+		},
+	],
+	baseRules
+);
 
 export default flexProps;

--- a/src/styleProps/marginProps.js
+++ b/src/styleProps/marginProps.js
@@ -1,34 +1,42 @@
 import {getSpacing} from '../utils/spacing';
-import {checkTheme} from '../utils/theme';
+import {createStyleFunction} from '../utils/styleProps';
 
-function marginProps(props) {
-	const {m, mx, my, mt, mr, mb, ml, theme} = props;
-
-	checkTheme(theme);
-
-	return {
-		margin: m ? getSpacing(m, theme) : undefined,
-		marginTop: my
-			? getSpacing(my, theme)
-			: mt
-			? getSpacing(mt, theme)
-			: undefined,
-		marginRight: mx
-			? getSpacing(mx, theme)
-			: mr
-			? getSpacing(mr, theme)
-			: undefined,
-		marginBottom: my
-			? getSpacing(my, theme)
-			: mb
-			? getSpacing(mb, theme)
-			: undefined,
-		marginLeft: mx
-			? getSpacing(mx, theme)
-			: ml
-			? getSpacing(ml, theme)
-			: undefined,
-	};
-}
+const marginProps = createStyleFunction([
+	{
+		styleProp: 'm',
+		properties: ['margin'],
+		getValue: getSpacing,
+	},
+	{
+		styleProp: 'mt',
+		properties: ['marginTop'],
+		getValue: getSpacing,
+	},
+	{
+		styleProp: 'mr',
+		properties: ['marginRight'],
+		getValue: getSpacing,
+	},
+	{
+		styleProp: 'mb',
+		properties: ['marginBottom'],
+		getValue: getSpacing,
+	},
+	{
+		styleProp: 'ml',
+		properties: ['marginLeft'],
+		getValue: getSpacing,
+	},
+	{
+		styleProp: 'mx',
+		properties: ['marginLeft', 'marginRight'],
+		getValue: getSpacing,
+	},
+	{
+		styleProp: 'my',
+		properties: ['marginTop', 'marginBottom'],
+		getValue: getSpacing,
+	},
+]);
 
 export default marginProps;

--- a/src/styleProps/paddingProps.js
+++ b/src/styleProps/paddingProps.js
@@ -1,34 +1,42 @@
 import {getSpacing} from '../utils/spacing';
-import {checkTheme} from '../utils/theme';
+import {createStyleFunction} from '../utils/styleProps';
 
-function paddingProps(props) {
-	const {p, px, py, pt, pr, pb, pl, theme} = props;
-
-	checkTheme(theme);
-
-	return {
-		padding: p ? getSpacing(p, theme) : undefined,
-		paddingTop: py
-			? getSpacing(py, theme)
-			: pt
-			? getSpacing(pt, theme)
-			: undefined,
-		paddingRight: px
-			? getSpacing(px, theme)
-			: pr
-			? getSpacing(pr, theme)
-			: undefined,
-		paddingBottom: py
-			? getSpacing(py, theme)
-			: pb
-			? getSpacing(pb, theme)
-			: undefined,
-		paddingLeft: px
-			? getSpacing(px, theme)
-			: pl
-			? getSpacing(pl, theme)
-			: undefined,
-	};
-}
+const paddingProps = createStyleFunction([
+	{
+		styleProp: 'p',
+		properties: ['padding'],
+		getValue: getSpacing,
+	},
+	{
+		styleProp: 'pt',
+		properties: ['paddingTop'],
+		getValue: getSpacing,
+	},
+	{
+		styleProp: 'pr',
+		properties: ['paddingRight'],
+		getValue: getSpacing,
+	},
+	{
+		styleProp: 'pb',
+		properties: ['paddingBottom'],
+		getValue: getSpacing,
+	},
+	{
+		styleProp: 'pl',
+		properties: ['paddingLeft'],
+		getValue: getSpacing,
+	},
+	{
+		styleProp: 'px',
+		properties: ['paddingLeft', 'paddingRight'],
+		getValue: getSpacing,
+	},
+	{
+		styleProp: 'py',
+		properties: ['paddingTop', 'paddingBottom'],
+		getValue: getSpacing,
+	},
+]);
 
 export default paddingProps;

--- a/src/styleProps/positionProps.js
+++ b/src/styleProps/positionProps.js
@@ -1,21 +1,42 @@
 import {getSpacing} from '../utils/spacing';
-import {checkTheme} from '../utils/styleProps';
+import {createStyleFunction} from '../utils/styleProps';
 
-function positionProps(props) {
-	const {pos, position, top, left, bottom, right, z, theme} = props;
-
-	checkTheme(theme);
-
-	return {
-		position: pos || position || undefined,
-
-		top: top ? getSpacing(top, theme) : undefined,
-		left: left ? getSpacing(left, theme) : undefined,
-		bottom: bottom ? getSpacing(bottom, theme) : undefined,
-		right: right ? getSpacing(right, theme) : undefined,
-
-		zIndex: (theme.globals.z && theme.globals.z[z]) || z || undefined,
-	};
-}
+const positionProps = createStyleFunction([
+	{
+		styleProp: 'position',
+		properties: ['position'],
+		getValue: value => value,
+	},
+	{
+		styleProp: 'pos',
+		properties: ['position'],
+		getValue: value => value,
+	},
+	{
+		styleProp: 'top',
+		properties: ['top'],
+		getValue: getSpacing,
+	},
+	{
+		styleProp: 'left',
+		properties: ['left'],
+		getValue: getSpacing,
+	},
+	{
+		styleProp: 'bottom',
+		properties: ['bottom'],
+		getValue: getSpacing,
+	},
+	{
+		styleProp: 'right',
+		properties: ['right'],
+		getValue: getSpacing,
+	},
+	{
+		styleProp: 'z',
+		properties: ['zIndex'],
+		getValue: (z, theme) => (theme.globals.z && theme.globals.z[z]) || z,
+	},
+]);
 
 export default positionProps;

--- a/src/styleProps/positionProps.js
+++ b/src/styleProps/positionProps.js
@@ -1,5 +1,5 @@
 import {getSpacing} from '../utils/spacing';
-import {checkTheme} from '../utils/theme';
+import {checkTheme} from '../utils/styleProps';
 
 function positionProps(props) {
 	const {pos, position, top, left, bottom, right, z, theme} = props;

--- a/src/styleProps/textProps.js
+++ b/src/styleProps/textProps.js
@@ -1,5 +1,5 @@
 import {alpha} from '../utils/colors';
-import {checkTheme} from '../utils/theme';
+import {checkTheme} from '../utils/styleProps';
 import {ellipsis, overflowWrap as wrap} from '../mixins';
 
 const textTransformMap = {

--- a/src/styleProps/textProps.js
+++ b/src/styleProps/textProps.js
@@ -5,6 +5,7 @@ import {ellipsis, overflowWrap as wrap} from '../mixins';
 const textTransformMap = {
 	all: 'uppercase',
 	first: 'capitalize',
+	none: 'none',
 };
 
 const overflowStylesMap = {
@@ -37,7 +38,7 @@ const textProps = createStyleFunction([
 	{
 		styleProp: 'caps',
 		properties: ['textTransform'],
-		getValue: caps => (caps ? textTransformMap[caps] : 'none'),
+		getValue: caps => textTransformMap[caps],
 	},
 	{
 		styleProp: 'dimmed',

--- a/src/styleProps/textProps.js
+++ b/src/styleProps/textProps.js
@@ -1,5 +1,5 @@
 import {alpha} from '../utils/colors';
-import {checkTheme} from '../utils/styleProps';
+import {createStyleFunction} from '../utils/styleProps';
 import {ellipsis, overflowWrap as wrap} from '../mixins';
 
 const textTransformMap = {
@@ -12,38 +12,44 @@ const overflowStylesMap = {
 	wrap,
 };
 
-function textProps(props) {
-	const {
-		bold,
-		caps,
-		dimmed,
-		fontSize,
-		lineHeight,
-		overflow,
-		textAlign,
-
-		theme,
-	} = props;
-
-	checkTheme(theme);
-
-	return {
-		textAlign,
-		fontSize: fontSize ? theme.globals.typeScale[fontSize] : undefined,
-		fontWeight: bold ? 'bold' : bold === false ? 'normal' : undefined,
-		lineHeight,
-		textTransform: caps
-			? textTransformMap[caps]
-			: caps === false
-			? 'none'
-			: undefined,
-		color: dimmed
-			? alpha(theme.text, theme.textDimStrength)
-			: dimmed === false
-			? theme.text
-			: undefined,
-		...(overflow ? overflowStylesMap[overflow] : undefined),
-	};
-}
+const textProps = createStyleFunction([
+	{
+		styleProp: 'bold',
+		properties: ['fontWeight'],
+		getValue: bold => (bold ? 'bold' : 'normal'),
+	},
+	{
+		styleProp: 'fontSize',
+		properties: ['fontSize'],
+		getValue: (size, theme) =>
+			size ? theme.globals.typeScale[size] : undefined,
+	},
+	{
+		styleProp: 'textAlign',
+		properties: ['textAlign'],
+		getValue: value => value,
+	},
+	{
+		styleProp: 'lineHeight',
+		properties: ['lineHeight'],
+		getValue: value => value,
+	},
+	{
+		styleProp: 'caps',
+		properties: ['textTransform'],
+		getValue: caps => (caps ? textTransformMap[caps] : 'none'),
+	},
+	{
+		styleProp: 'dimmed',
+		properties: ['color'],
+		getValue: (dimmed, theme) =>
+			dimmed ? alpha(theme.text, theme.textDimStrength) : theme.text,
+	},
+	{
+		styleProp: 'overflow',
+		getRules: overflow =>
+			overflow ? overflowStylesMap[overflow] : undefined,
+	},
+]);
 
 export default textProps;

--- a/src/theme/globals.js
+++ b/src/theme/globals.js
@@ -7,13 +7,13 @@ const lineHeight = 1.5;
 const maxPageWidth = 1200;
 
 const typeScale = {
-	xxs: pxToRem(rootFontSize * 0.75),
-	xs: pxToRem(rootFontSize * 0.875),
-	s: pxToRem(rootFontSize * 0.9375),
-	m: pxToRem(rootFontSize),
-	l: pxToRem(rootFontSize * 1.125),
-	xl: pxToRem(rootFontSize * 1.375),
-	xxl: pxToRem(rootFontSize * 1.625),
+	xxs: pxToRem(fontSize * 0.75),
+	xs: pxToRem(fontSize * 0.875),
+	s: pxToRem(fontSize * 0.9375),
+	m: pxToRem(fontSize),
+	l: pxToRem(fontSize * 1.125),
+	xl: pxToRem(fontSize * 1.375),
+	xxl: pxToRem(fontSize * 1.625),
 };
 
 const spacing = {

--- a/src/utils/styleProps.js
+++ b/src/utils/styleProps.js
@@ -8,10 +8,14 @@ function checkTheme(theme) {
 
 /**
  * Retrieve a responsive style prop's value.
- * If prop is not an array, return raw value
+ * If prop is not an array, it means it's not responsive and only needs to be
+ * set at the base breakpoint (i.e. index === 0), so we return undefined for
+ * any index larger than 0.
  *
  * @param {string|number|Array} prop - Prop passed to the component
  * @param {number} index - index used to retrieve value if prop is an array
+ *
+ * @returns {string|number} - A CSS property value
  */
 
 function getValueByIndex(prop, index = 0) {
@@ -29,33 +33,34 @@ function getValueByIndex(prop, index = 0) {
  *
  * @param {object[]} stylePropConfig - Style prop configuration objects
  * @param {string} stylePropConfig[].styleProp - Name of the style prop
- * @param {Array|Function} stylePropConfig[].properties - Array of the CSS properties
- * to set, or a function to create such an array
- * @param {Function} stylePropConfig[].getValue - Transforms the prop value into a
- * valid CSS property value
- * @param {object} passedProps
- * @param {number} breakpointIndex
+ * @param {Array} stylePropConfig[].properties - The CSS properties that the value should be applied to
+ * @param {Function} stylePropConfig[].getValue - Transforms the prop value into a valid CSS property value.
+ * This function is only called when the prop's value is not null or undefined.
+ * @param {Function} stylePropConfig[].getRules - Use this instead of stylePropConfig.properties and stylePropConfig.getValue to define more complex style props that need to generate multiple CSS rules. Will be called with any value, so you have to make sure to return a falsy value if you don't want to add a rule.
+ * @param {object} componentProps - Props that the component was called with
+ * @param {number} breakpointIndex - If the passed prop is an array of responsive values, this number tells us which value to pick from the array
+ *
+ * @returns {object} - A CSS rule set
  */
 
-function getStylePropRules(stylePropConfig, passedProps, breakpointIndex) {
+function getStylePropRules(stylePropConfig, componentProps, breakpointIndex) {
 	const rules = {};
 	stylePropConfig.forEach(
 		({styleProp: stylePropKey, properties, getValue, getRules}) => {
 			const styleProp = getValueByIndex(
-				passedProps[stylePropKey],
+				componentProps[stylePropKey],
 				breakpointIndex
 			);
 
 			if (typeof getRules === 'function') {
-				Object.assign(rules, getRules(styleProp, passedProps.theme));
+				const rulesToAdd = getRules(styleProp, componentProps.theme);
+				if (rulesToAdd) {
+					Object.assign(rules, rulesToAdd);
+				}
 			} else {
-				const definedProps =
-					typeof properties === 'function'
-						? properties(styleProp)
-						: properties;
 				if (styleProp !== undefined && styleProp !== null) {
-					definedProps.forEach(prop => {
-						rules[prop] = getValue(styleProp, passedProps.theme);
+					properties.forEach(prop => {
+						rules[prop] = getValue(styleProp, componentProps.theme);
 					});
 				}
 			}
@@ -64,11 +69,11 @@ function getStylePropRules(stylePropConfig, passedProps, breakpointIndex) {
 	return rules;
 }
 
-function getResponsiveRules(stylePropConfig, passedProps) {
+function getResponsiveRules(stylePropConfig, componentProps) {
 	// Get baseline styles
-	const rules = getStylePropRules(stylePropConfig, passedProps, 0);
+	const rules = getStylePropRules(stylePropConfig, componentProps, 0);
 
-	const {breakpoints} = passedProps;
+	const {breakpoints} = componentProps;
 	if (!breakpoints) {
 		return rules;
 	}
@@ -77,11 +82,11 @@ function getResponsiveRules(stylePropConfig, passedProps) {
 	const bps = Array.isArray(breakpoints) ? breakpoints : [breakpoints];
 	bps.forEach((breakpoint, index) => {
 		const breakpointWidth =
-			passedProps.theme.globals.breakpoints[breakpoint] || breakpoint;
+			componentProps.theme.globals.breakpoints[breakpoint] || breakpoint;
 		const breakpointQuery = `@media screen and (min-width: ${breakpointWidth})`;
 		rules[breakpointQuery] = getStylePropRules(
 			stylePropConfig,
-			passedProps,
+			componentProps,
 			index + 1
 		);
 	});
@@ -90,21 +95,21 @@ function getResponsiveRules(stylePropConfig, passedProps) {
 }
 
 /**
- * Generates a style prop function that can be used directly in a styled
- * component, e.g.
+ *
+ * @param {object[]} stylePropConfig - Style prop configuration objects
+ * @param {string} stylePropConfig[].styleProp - Name of the style prop
+ * @param {Array} stylePropConfig[].properties - The CSS properties that the value should be applied to
+ * @param {Function} stylePropConfig[].getValue - Transforms the prop value into a valid CSS property value.
+ * This function is only called when the prop's value is not null or undefined.
+ * @param {Function} stylePropConfig[].getRules - Use this instead of stylePropConfig.properties and stylePropConfig.getValue to define more complex style props that need to generate multiple CSS rules. Will be called with any value, so you have to make sure to return a falsy value if you don't want to add a rule.
+ * @param {object} [baseRules] - Any static CSS rules to add before the dynamic styleProp rules
+ *
+ * @returns {Function} - A responsive style prop function that can be used directly in a styled component, e.g.
  * ```
  * const MyLink = styled.a`
  *   ${myStyleProp}
  * `
  * ```
- *
- * @param {object[]} stylePropConfig - Style prop configuration objects
- * @param {string} stylePropConfig[].styleProp - Name of the style prop
- * @param {Array|Function} stylePropConfig[].properties - Array of the CSS properties
- * to set, or a function to create such an array
- * @param {Function} stylePropConfig[].getValue - Transforms the prop value into a
- * valid CSS property value
- * @param {object} [baseRules] - Any basic/static CSS rules to add
  */
 
 function createStyleFunction(stylePropConfig, baseRules) {

--- a/src/utils/styleProps.js
+++ b/src/utils/styleProps.js
@@ -1,0 +1,112 @@
+import {ThemeSectionError} from '../ThemeSection';
+
+function checkTheme(theme) {
+	if (!theme || !theme.globals) {
+		throw new ThemeSectionError();
+	}
+}
+
+/**
+ * Retrieve a responsive style prop's value.
+ * If prop is not an array, return raw value
+ *
+ * @param {string|number|Array} prop - Prop passed to the component
+ * @param {number} index - index used to retrieve value if prop is an array
+ */
+
+function getValueByIndex(prop, index = 0) {
+	if (Array.isArray(prop)) {
+		return prop[index];
+	}
+	if (index > 0) {
+		return undefined;
+	}
+	return prop;
+}
+
+/**
+ * Builds a CSS ruleset based on the props passed to the component.
+ *
+ * @param {object[]} stylePropConfig - Style prop configuration objects
+ * @param {string} stylePropConfig[].styleProp - Name of the style prop
+ * @param {Array|Function} stylePropConfig[].properties - Array of the CSS properties
+ * to set, or a function to create such an array
+ * @param {Function} stylePropConfig[].getValue - Transforms the prop value into a
+ * valid CSS property value
+ * @param {object} passedProps
+ * @param {number} breakpointIndex
+ */
+
+function getStylePropRules(stylePropConfig, passedProps, breakpointIndex) {
+	const rules = {};
+	stylePropConfig.forEach(
+		({styleProp: stylePropKey, properties, getValue}) => {
+			const styleProp = getValueByIndex(
+				passedProps[stylePropKey],
+				breakpointIndex
+			);
+			const definedProps =
+				typeof properties === 'function'
+					? properties(styleProp)
+					: properties;
+			if (styleProp) {
+				definedProps.forEach(prop => {
+					rules[prop] = getValue(styleProp, passedProps.theme);
+				});
+			}
+		}
+	);
+	return rules;
+}
+
+function getResponsiveRules(stylePropConfig, passedProps) {
+	// Get baseline styles
+	const rules = getStylePropRules(stylePropConfig, passedProps, 0);
+
+	const {breakpoints} = passedProps;
+	if (!breakpoints) {
+		return rules;
+	}
+
+	// If any breakpoints exist, add them to the rule set
+	const bps = Array.isArray(breakpoints) ? breakpoints : [breakpoints];
+	bps.forEach((breakpoint, index) => {
+		const breakpointWidth =
+			passedProps.theme.globals.breakpoints[breakpoint] || breakpoint;
+		const breakpointQuery = `@media screen and (min-width: ${breakpointWidth})`;
+		rules[breakpointQuery] = getStylePropRules(
+			stylePropConfig,
+			passedProps,
+			index + 1
+		);
+	});
+
+	return rules;
+}
+
+/**
+ * Generates a style prop function that can be used directly in a styled
+ * component, e.g.
+ * ```
+ * const MyLink = styled.a`
+ *   ${myStyleProp}
+ * `
+ * ```
+ *
+ * @param {object[]} stylePropConfig - Style prop configuration objects
+ * @param {string} stylePropConfig[].styleProp - Name of the style prop
+ * @param {Array|Function} stylePropConfig[].properties - Array of the CSS properties
+ * to set, or a function to create such an array
+ * @param {Function} stylePropConfig[].getValue - Transforms the prop value into a
+ * valid CSS property value
+ */
+
+function createStyleFunction(stylePropConfig) {
+	return function styleFunction(props) {
+		checkTheme(props.theme);
+		const rules = getResponsiveRules(stylePropConfig, props);
+		return rules;
+	};
+}
+
+export {checkTheme, createStyleFunction};

--- a/src/utils/styleProps.js
+++ b/src/utils/styleProps.js
@@ -40,19 +40,24 @@ function getValueByIndex(prop, index = 0) {
 function getStylePropRules(stylePropConfig, passedProps, breakpointIndex) {
 	const rules = {};
 	stylePropConfig.forEach(
-		({styleProp: stylePropKey, properties, getValue}) => {
+		({styleProp: stylePropKey, properties, getValue, getRules}) => {
 			const styleProp = getValueByIndex(
 				passedProps[stylePropKey],
 				breakpointIndex
 			);
-			const definedProps =
-				typeof properties === 'function'
-					? properties(styleProp)
-					: properties;
-			if (styleProp) {
-				definedProps.forEach(prop => {
-					rules[prop] = getValue(styleProp, passedProps.theme);
-				});
+
+			if (typeof getRules === 'function') {
+				Object.assign(rules, getRules(styleProp));
+			} else {
+				const definedProps =
+					typeof properties === 'function'
+						? properties(styleProp)
+						: properties;
+				if (styleProp !== undefined || styleProp !== null) {
+					definedProps.forEach(prop => {
+						rules[prop] = getValue(styleProp, passedProps.theme);
+					});
+				}
 			}
 		}
 	);

--- a/src/utils/styleProps.js
+++ b/src/utils/styleProps.js
@@ -47,7 +47,7 @@ function getStylePropRules(stylePropConfig, passedProps, breakpointIndex) {
 			);
 
 			if (typeof getRules === 'function') {
-				Object.assign(rules, getRules(styleProp));
+				Object.assign(rules, getRules(styleProp, passedProps.theme));
 			} else {
 				const definedProps =
 					typeof properties === 'function'

--- a/src/utils/styleProps.js
+++ b/src/utils/styleProps.js
@@ -53,7 +53,7 @@ function getStylePropRules(stylePropConfig, passedProps, breakpointIndex) {
 					typeof properties === 'function'
 						? properties(styleProp)
 						: properties;
-				if (styleProp !== undefined || styleProp !== null) {
+				if (styleProp !== undefined && styleProp !== null) {
 					definedProps.forEach(prop => {
 						rules[prop] = getValue(styleProp, passedProps.theme);
 					});

--- a/src/utils/styleProps.js
+++ b/src/utils/styleProps.js
@@ -104,12 +104,19 @@ function getResponsiveRules(stylePropConfig, passedProps) {
  * to set, or a function to create such an array
  * @param {Function} stylePropConfig[].getValue - Transforms the prop value into a
  * valid CSS property value
+ * @param {object} [baseRules] - Any basic/static CSS rules to add
  */
 
-function createStyleFunction(stylePropConfig) {
+function createStyleFunction(stylePropConfig, baseRules) {
 	return function styleFunction(props) {
 		checkTheme(props.theme);
 		const rules = getResponsiveRules(stylePropConfig, props);
+		if (baseRules) {
+			return {
+				...baseRules,
+				...rules,
+			};
+		}
 		return rules;
 	};
 }

--- a/src/utils/theme.js
+++ b/src/utils/theme.js
@@ -1,9 +1,0 @@
-import {ThemeSectionError} from '../ThemeSection';
-
-function checkTheme(theme) {
-	if (!theme || !theme.globals) {
-		throw new ThemeSectionError();
-	}
-}
-
-export {checkTheme};


### PR DESCRIPTION
This PR makes base5-ui's style props much more powerful by employing an inline component styling method inspired by [styled-system](https://styled-system.com).

Style props are the (shorthand) props that the `Box` and `Text` components are built upon. They allow setting basic styles directly on the component, e.g. `<Box p="m" fontSize="xl" />` to render a plain `div` with medium padding and an extra-large font-size. These values can now be made responsive. To do this, first add a `breakpoints` prop to the component:
```jsx
<Box breakpoints={['s', 'xl']} p="m" fontSize="xl" />
```

By itself this won't change anything about the rendered component, except that you can now pass an array of sizes to the `p` and `fontSize` props for responsive values.
```jsx
<Box
   breakpoints={['s', 'xl']}
   p={['xs', 'm', 'l']}
   fontSize={['m', 'xl']}
/>
```
This component will now have small padding on small viewports (anything below breakpoint "s"), medium padding on larger ones, and large padding on viewports above breakpoint "xl".

The styles are mobile-first, i.e. the first value is what you'll get on the smallest viewport, while any additional values are added at the next-smallest breakpoint. The `breakpoints` prop also accepts a string as a value if only a single breakpoint is needed.

This change should greatly reduce the need to write custom CSS when building new layouts, widgets, and UI components.