### PR TITLE
fix: pass props through InnerBodyScrollLock component

### DIFF
--- a/src/Modal/BodyScrollLock.js
+++ b/src/Modal/BodyScrollLock.js
@@ -35,7 +35,7 @@ function useScrollLockStyles({isLocked}) {
 }
 
 function InnerBodyScrollLock(props, ref) {
-	const {as: Component = 'div', children, style, ...rest} = props;
+	const {as: Component = 'div', children, style, ...otherProps} = props;
 	const modalStack = useContext(ModalStackContext);
 	const hasModal = modalStack?.length;
 	const bodyLockStyles = useScrollLockStyles({isLocked: hasModal});
@@ -44,7 +44,7 @@ function InnerBodyScrollLock(props, ref) {
 		<Component
 			ref={ref}
 			style={style ? {...style, ...bodyLockStyles} : bodyLockStyles}
-			{...rest}
+			{...otherProps}
 		>
 			{children}
 		</Component>

--- a/src/Modal/BodyScrollLock.js
+++ b/src/Modal/BodyScrollLock.js
@@ -35,7 +35,7 @@ function useScrollLockStyles({isLocked}) {
 }
 
 function InnerBodyScrollLock(props, ref) {
-	const {as: Component = 'div', children, style} = props;
+	const {as: Component = 'div', children, style, ...rest} = props;
 	const modalStack = useContext(ModalStackContext);
 	const hasModal = modalStack?.length;
 	const bodyLockStyles = useScrollLockStyles({isLocked: hasModal});
@@ -44,6 +44,7 @@ function InnerBodyScrollLock(props, ref) {
 		<Component
 			ref={ref}
 			style={style ? {...style, ...bodyLockStyles} : bodyLockStyles}
+			{...rest}
 		>
 			{children}
 		</Component>


### PR DESCRIPTION
**Proposed changes:**

After destructuring {`as`, `children` and `style`} out of the props, pass the {...rest} through to the component it renders.

**This fixes:**

This lets you do things like giving the ScrollLock element an id, aria-tags, etc.