### PR TITLE
feat(Time): Add readout overrides 5app/dashboard#8221

### DIFF
--- a/src/Time/getDateString.js
+++ b/src/Time/getDateString.js
@@ -13,7 +13,19 @@ function date(d) {
 	}
 }
 
-function getDateString({dateTime, locale, systemOffset = 0}) {
+function getDateString({
+	dateTime,
+	locale,
+	systemOffset = 0,
+	readoutFunctions = {},
+}) {
+	// Set default readout functions
+	const {
+		secondsAgoReadout = () => `seconds ago`,
+		minutesAgoReadout = count =>
+			`${count ? count : '< 1'} minute${count > 1 ? 's' : ''} ago`,
+	} = readoutFunctions;
+
 	// Define the offset, how old is this...
 	const time = date(dateTime);
 
@@ -37,18 +49,19 @@ function getDateString({dateTime, locale, systemOffset = 0}) {
 	// A few seconds ago
 	if (offset < TIME_MINUTE / 2) {
 		delay = TIME_MINUTE / 2 - offset;
-		dateString = 'seconds ago';
+		const seconds = parseInt(offset / 1000);
+		dateString = secondsAgoReadout(seconds);
 	}
 	// Less than a minute ago
 	else if (offset < TIME_MINUTE) {
 		delay = TIME_MINUTE - offset;
-		dateString = '< 1 minute ago';
+		dateString = minutesAgoReadout(0);
 	}
 	// A few minutes ago
 	else if (offset < TIME_MINUTE * 10) {
 		delay = TIME_MINUTE;
 		const mins = parseInt(offset / TIME_MINUTE);
-		dateString = `${mins} minute${mins > 1 ? 's' : ''} ago`;
+		dateString = minutesAgoReadout(mins);
 	}
 	// Occcured today...
 	else if (offset < ms_today) {

--- a/src/Time/getDateString.js
+++ b/src/Time/getDateString.js
@@ -1,6 +1,7 @@
-const TIME_MINUTE = 60 * 1000;
-const TIME_HOUR = 60 * TIME_MINUTE;
-const TIME_DAY = 24 * TIME_HOUR;
+const ONE_SECOND = 1000;
+const ONE_MINUTE = 60 * ONE_SECOND;
+const ONE_HOUR = 60 * ONE_MINUTE;
+const ONE_DAY = 24 * ONE_HOUR;
 
 function date(d) {
 	if (!d) {
@@ -21,9 +22,10 @@ function getDateString({
 }) {
 	// Set default readout functions
 	const {
-		secondsAgoReadout = () => `seconds ago`,
+		secondsAgoReadout = count =>
+			`${count} second${count > 1 ? 's' : ''} ago`,
 		minutesAgoReadout = count =>
-			`${count ? count : '< 1'} minute${count > 1 ? 's' : ''} ago`,
+			`${count} minute${count > 1 ? 's' : ''} ago`,
 	} = readoutFunctions;
 
 	// Define the offset, how old is this...
@@ -40,33 +42,29 @@ function getDateString({
 
 	// Get the number of milliseconds since midnight in the local tz
 	const ms_today =
-		(Date.now() - new Date().getTimezoneOffset() * 1000 * 60) % TIME_DAY;
+		(Date.now() - new Date().getTimezoneOffset() * 1000 * 60) % ONE_DAY;
 	let dateString = 'n/a';
 
 	// Default delay
 	let delay = null;
 
 	// A few seconds ago
-	if (offset < TIME_MINUTE / 2) {
-		delay = TIME_MINUTE / 2 - offset;
+	if (offset < ONE_MINUTE) {
+		const FIVE_SECONDS = ONE_SECOND * 5;
+		delay = offset % FIVE_SECONDS || FIVE_SECONDS;
 		const seconds = parseInt(offset / 1000);
-		dateString = secondsAgoReadout(seconds);
-	}
-	// Less than a minute ago
-	else if (offset < TIME_MINUTE) {
-		delay = TIME_MINUTE - offset;
-		dateString = minutesAgoReadout(0);
+		dateString = secondsAgoReadout(seconds || ONE_SECOND);
 	}
 	// A few minutes ago
-	else if (offset < TIME_MINUTE * 10) {
-		delay = TIME_MINUTE;
-		const mins = parseInt(offset / TIME_MINUTE);
+	else if (offset < ONE_MINUTE * 10) {
+		delay = offset % ONE_MINUTE || ONE_MINUTE;
+		const mins = parseInt(offset / ONE_MINUTE);
 		dateString = minutesAgoReadout(mins);
 	}
 	// Occcured today...
 	else if (offset < ms_today) {
 		// Number of ms until end of the day...
-		delay = TIME_DAY - ms_today;
+		delay = ONE_DAY - ms_today;
 		dateString = new Intl.DateTimeFormat(locale, {
 			hourCycle: 'h12',
 			hour: 'numeric',
@@ -74,9 +72,9 @@ function getDateString({
 		}).format(time);
 	}
 	// Occurred this week
-	else if (offset < TIME_DAY * 6) {
+	else if (offset < ONE_DAY * 6) {
 		// Delay a day...
-		delay = TIME_DAY;
+		delay = ONE_DAY;
 		// Get day
 		dateString = new Intl.DateTimeFormat(locale, {
 			weekday: 'short',

--- a/src/Time/index.js
+++ b/src/Time/index.js
@@ -18,7 +18,7 @@ function useForceUpdate() {
  * @param {object} opts.readoutFunctions - Object for handling translations
  * @returns {Function} React Hook
  */
-function Time({dateTime, systemTime, readoutFunctions, locale}) {
+function Time({dateTime, systemTime, readoutFunctions, locale, ...props}) {
 	const forceUpdate = useForceUpdate();
 
 	// Offset system time with local time...
@@ -40,7 +40,11 @@ function Time({dateTime, systemTime, readoutFunctions, locale}) {
 	const title = date(dateTime);
 
 	return (
-		<time dateTime={dateTime} title={title && title.toLocaleString()}>
+		<time
+			dateTime={dateTime}
+			title={title && title.toLocaleString()}
+			{...props}
+		>
 			{dateString || 'n/a'}
 		</time>
 	);

--- a/src/Time/index.js
+++ b/src/Time/index.js
@@ -9,7 +9,16 @@ function useForceUpdate() {
 	return forceUpdate;
 }
 
-function Time({dateTime, systemTime, locale}) {
+/**
+ * Relative Time component
+ * @param {object} opts - Options
+ * @param {string|Date} opts.dateTime - Date of the event
+ * @param {string|Date} opts.systemTime - Base time (used in testing)
+ * @param {string} opts.locale - Locale of the user, otherwise uses agent default
+ * @param {object} opts.readoutFunctions - Object for handling translations
+ * @returns {Function} React Hook
+ */
+function Time({dateTime, systemTime, readoutFunctions, locale}) {
 	const forceUpdate = useForceUpdate();
 
 	// Offset system time with local time...
@@ -19,6 +28,7 @@ function Time({dateTime, systemTime, locale}) {
 
 	// Get the date string and the delay before running the next loop
 	const [dateString, delay] = getDateString({
+		readoutFunctions,
 		dateTime,
 		locale,
 		systemOffset: systemOffset.current,
@@ -49,6 +59,7 @@ Time.propTypes = {
 		PropTypes.instanceOf(Date),
 		PropTypes.string,
 	]),
+	readoutFunctions: PropTypes.object,
 };
 
 // @component

--- a/src/Time/index.spec.js
+++ b/src/Time/index.spec.js
@@ -6,6 +6,20 @@ import '@testing-library/jest-dom/extend-expect';
 describe('Time', () => {
 	afterEach(cleanup);
 
+	it('passes through props like `id`', () => {
+		const id = 'passthrough-prop';
+		const dateTime = '2019-02-27T12:06:14Z';
+
+		const {container} = render(<Time dateTime={dateTime} id={id} />);
+
+		const time = container.querySelector('time');
+
+		expect(time).toBeInTheDocument();
+		expect(time).toHaveAttribute('title');
+		expect(time).toHaveAttribute('dateTime', dateTime);
+		expect(time).toHaveAttribute('id', id);
+	});
+
 	[
 		{
 			offset: 1,
@@ -27,15 +41,15 @@ describe('Time', () => {
 	].forEach(({offset, text, dateStr, systemTime}) => {
 		let dateTime = dateStr;
 
+		if (!dateTime) {
+			const date = new Date();
+			date.setTime(date.getTime() - offset * 1000);
+			dateTime = date.toISOString();
+		}
+
 		it(`renders time as relative text ${
 			offset ? `, offset:${offset}` : ''
 		}${dateTime ? `, dateTime:${dateTime}` : ''}, expect ${text}`, () => {
-			if (!dateTime) {
-				const date = new Date();
-				date.setTime(date.getTime() - offset * 1000);
-				dateTime = date.toISOString();
-			}
-
 			const {container} = render(
 				<Time dateTime={dateTime} systemTime={systemTime} />
 			);
@@ -50,5 +64,36 @@ describe('Time', () => {
 			expect(time).toHaveAttribute('dateTime', dateTime);
 			expect(time).toHaveTextContent(text);
 		});
+
+		if (offset) {
+			it(`lets us use custom readout functions`, () => {
+				const count = offset > 30 ? parseInt(offset / 60) : offset;
+
+				const elephants = count => `${count} elephants`;
+
+				const readoutFunctions = {
+					secondsAgoReadout: elephants,
+					minutesAgoReadout: elephants,
+				};
+
+				const {container} = render(
+					<Time
+						dateTime={dateTime}
+						systemTime={systemTime}
+						readoutFunctions={readoutFunctions}
+					/>
+				);
+
+				const time = container.querySelector('time');
+
+				expect(time).toBeInTheDocument();
+				expect(time).toHaveAttribute(
+					'title',
+					new Date(dateTime).toLocaleString()
+				);
+				expect(time).toHaveAttribute('dateTime', dateTime);
+				expect(time).toHaveTextContent(elephants(count));
+			});
+		}
 	});
 });

--- a/src/Time/index.spec.js
+++ b/src/Time/index.spec.js
@@ -23,11 +23,11 @@ describe('Time', () => {
 	[
 		{
 			offset: 1,
-			text: 'seconds ago',
+			text: '1 second ago',
 		},
 		{
 			offset: 33,
-			text: '< 1 minute ago',
+			text: '33 seconds ago',
 		},
 		{
 			offset: 90,
@@ -67,7 +67,7 @@ describe('Time', () => {
 
 		if (offset) {
 			it(`lets us use custom readout functions`, () => {
-				const count = offset > 30 ? parseInt(offset / 60) : offset;
+				const count = offset > 60 ? parseInt(offset / 60) : offset;
 
 				const elephants = count => `${count} elephants`;
 


### PR DESCRIPTION
For 5app/dashboard#8221 see comments in https://github.com/5app/dashboard/pull/8225#issuecomment-660996737

Adds support for `readoutFunctions{}`

```jsx
<Time
dateTime="2019-02-27T12:06:14Z"
readoutFunction={{
      secondsAgoReadout = () => `seconds ago`,
      minutesAgoReadout = () => `minutes ago`,
}}
/>
```