### PR TITLE
fix: disregard null-ish items when considering whether to apply spacing

### DIFF
--- a/src/Stack/index.js
+++ b/src/Stack/index.js
@@ -17,12 +17,13 @@ const roles = {
 function Stack({children, spacing, breakpoints, as, ...otherProps}) {
 	const wrapperAs = roles[as]?.wrapper;
 	const itemAs = roles[as]?.item;
+	let renderCount = 0;
 	return (
 		<Box as={wrapperAs} breakpoints={breakpoints} {...otherProps}>
-			{React.Children.map(children, (child, index) => {
+			{React.Children.map(children, child => {
 				if (!child) return null;
 
-				const isFirst = index === 0;
+				const isFirst = !renderCount++;
 				return (
 					<Box
 						as={itemAs}


### PR DESCRIPTION
fixes #noissue

If the first item in a `<stack />` is conditional'ed out, it would still show up as `null` in the children, meaning it increases the index in `React.Children.map(children, (child, index) => { ...` making the `isFirst` value inaccurate:

```javascript
const Test = () => (
  <Stack>
   {null}  // this still shows up in the `children` prop, meaning the `1` receives spacing even though it's the first item
    <>1</>
    <>2</>
    <>3</>
  </Stack>
);
```

@5app/devs 
