### PR TITLE
fix: Fix focusing on nullish modal elements

### DIFF
--- a/src/Modal/ModalManager.js
+++ b/src/Modal/ModalManager.js
@@ -86,14 +86,14 @@ function ModalManager({children}) {
 	// Focus the element that originally opened the modal
 	// There should only be one after a modal was un-registered)
 	useEffect(() => {
-		if (elementToFocus.current) {
-			// The timeout is needed to allow the focus lock script
-			// (react-focus-lock) to unlock the focus target
-			setTimeout(() => {
+		// The timeout is needed to allow the focus lock script
+		// (react-focus-lock) to unlock the focus target
+		setTimeout(() => {
+			if (elementToFocus.current) {
 				elementToFocus.current.focus();
 				elementToFocus.current = null;
-			}, 0);
-		}
+			}
+		}, 0);
 	}, [modalStack]);
 
 	// Apply aria-hidden to everything but the top-most modal.


### PR DESCRIPTION
Check if components are not null before resetting the focus on modal's main element.

![image](https://user-images.githubusercontent.com/1769608/90260901-1cc47180-de44-11ea-9160-371cca8e562a.png)


noissue