### PR TITLE
fix(Time): component in tests, add locale

### DIFF
--- a/src/Time/index.js
+++ b/src/Time/index.js
@@ -63,6 +63,7 @@ Time.propTypes = {
 		PropTypes.instanceOf(Date),
 		PropTypes.string,
 	]),
+	locale: PropTypes.string,
 	readoutFunctions: PropTypes.object,
 };
 

--- a/src/Time/index.spec.js
+++ b/src/Time/index.spec.js
@@ -51,7 +51,7 @@ describe('Time', () => {
 			offset ? `, offset:${offset}` : ''
 		}${dateTime ? `, dateTime:${dateTime}` : ''}, expect ${text}`, () => {
 			const {container} = render(
-				<Time dateTime={dateTime} systemTime={systemTime} />
+				<Time dateTime={dateTime} systemTime={systemTime} locale="en" />
 			);
 
 			const time = container.querySelector('time');


### PR DESCRIPTION
Adds the locale, so formats the `PM/pm` issue locally, may also resolve the offset issue we're seeing

<img width="644" alt="Screenshot 2021-05-28 at 11 53 03" src="https://user-images.githubusercontent.com/947163/119975007-456dc000-bfad-11eb-9e5f-929b89e41b9d.png">
