### PR TITLE
chore(ci): update circleci node base image, noissue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ executors:
   default:
     working_directory: *dir
     docker:
-      - image: circleci/node:lts
+      - image: cimg/node:lts
 
 
 ################################


### PR DESCRIPTION
Updates the node base image in our circleci config, after we received the following email advice...

> Why migrate?
> - More deterministic: The newest images will be rebuilt only for security and critical-bugs, drastically reducing breaking changes from updates in legacy images.
> - Faster build times: Our newest images get faster as our community uses them due to improved caching. Migrating to the new image is good for your builds and for the builds of the larger Node.js community.
> - As of Dec 31, 2021, legacy images will no longer be supported on CircleCI. View more information on our image deprecation timeline here.


... they should have lead with the deprecation notice (the last point)
