### PR TITLE
chore(ci): fix broken dep cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,8 @@ aliases:
   - &attach_workspace
     attach_workspace:
       at: *dir
-  - &cache-key dependency-cache-lts-{{ checksum "package.json" }}
-  - &cache-key-fallback dependency-cache-
+  - &cache-key dependency-cache-lts-a-{{ checksum "package.json" }}
+  - &cache-key-fallback dependency-cache-lts-a-
 
 ################################
 # Executors


### PR DESCRIPTION
Fixes [broken cache in circleci ](https://app.circleci.com/pipelines/github/5app/base5-ui/1673/workflows/fab7938c-0196-4bd1-87eb-2df9e2882b34/jobs/3498)