### PR TITLE
fix: improve pill accessibility, #noissue

### DIFF
--- a/src/Pill/README.stories.mdx
+++ b/src/Pill/README.stories.mdx
@@ -33,6 +33,9 @@ Pills can be made clickable, but should never be used as action buttons (think "
 			<Pill icon="tag" iconColor="neutral">
 				Pill with icon
 			</Pill>
+			<Pill iconOnly icon="globe" iconColor="neutral">
+				Pill with icon but no visible label
+			</Pill>
 			<Pill dimmed icon="user" iconColor="negative">
 				Dimmed pill with icon
 			</Pill>
@@ -66,6 +69,24 @@ To make a Pill's body clickable, simply attach an `onClick` handler. You can als
 				Delete-able Pill with icon
 			</Pill>
 			<Pill onClick={() => console.log('Hello!')}>Clickable pill</Pill>
+			<Pill
+				iconOnly
+				icon="globe"
+				iconColor="neutral"
+				onClick={() => console.log('Hello world!')}
+			>
+				Pill with icon but no visible label which can be deleted
+			</Pill>
+			<Pill
+				iconOnly
+				icon="star"
+				iconColor="positive"
+				onClick={() => console.log('Hello world!')}
+				onDelete={() => console.log('Delete')}
+				deleteLabel="Delete"
+			>
+				Pill with icon but no visible label
+			</Pill>
 			<Pill
 				onClick={() => console.log('Hello!')}
 				icon="external"

--- a/src/Pill/README.stories.mdx
+++ b/src/Pill/README.stories.mdx
@@ -75,17 +75,17 @@ To make a Pill's body clickable, simply attach an `onClick` handler. You can als
 				iconColor="neutral"
 				onClick={() => console.log('Hello world!')}
 			>
-				Pill with icon but no visible label which can be deleted
+				Pill with icon but no visible label
 			</Pill>
 			<Pill
 				iconOnly
 				icon="star"
 				iconColor="positive"
-				onClick={() => console.log('Hello world!')}
+				onClick={() => console.log('You get a star!')}
 				onDelete={() => console.log('Delete')}
 				deleteLabel="Delete"
 			>
-				Pill with icon but no visible label
+				Pill with icon but no visible label which can be deleted
 			</Pill>
 			<Pill
 				onClick={() => console.log('Hello!')}

--- a/src/Pill/index.js
+++ b/src/Pill/index.js
@@ -22,6 +22,7 @@ import Text from '../Text';
 import Icon from '../Icon';
 import ThemeSection from '../ThemeSection';
 import useUniqueId from '../useUniqueId';
+import VisuallyHidden from '../VisuallyHidden';
 
 import {marginPropsDef} from '../styleProps/marginProps';
 
@@ -260,11 +261,12 @@ function splitMarginProps(props) {
 
 const Pill = forwardRef((props, ref) => {
 	const {
+		iconOnly = false,
+		dimmed,
 		as,
 		background,
 		children,
 		deleteLabel,
-		dimmed,
 		forwardedAs,
 		icon,
 		iconColor,
@@ -321,9 +323,13 @@ const Pill = forwardRef((props, ref) => {
 						{token}
 					</Box>
 				)}
-				<Text display="block" overflow="ellipsis">
-					{children}
-				</Text>
+				{iconOnly ? (
+					<VisuallyHidden>{children}</VisuallyHidden>
+				) : (
+					<Text display="block" overflow="ellipsis">
+						{children}
+					</Text>
+				)}
 			</Wrapper>
 			{hasSideButton && (
 				<SideButton
@@ -354,7 +360,7 @@ Pill.propTypes = {
 	/**
 	 * Label of the pill to be shown
 	 */
-	children: PropTypes.string,
+	children: PropTypes.node.isRequired,
 	/**
 	 * Name of the icon to be shown
 	 */
@@ -378,6 +384,10 @@ Pill.propTypes = {
 	 * indicate e.g. partial matches in a group of items.
 	 */
 	dimmed: PropTypes.bool,
+	/**
+	 * Visually hides the label but uses it for accessibility.
+	 */
+	iconOnly: PropTypes.bool,
 	/**
 	 * When an ID is passed, it will be applied to the main pill element with the suffix
 	 * "_wrapper", and to the delete button with the suffix "_side_button"

--- a/src/Pill/index.js
+++ b/src/Pill/index.js
@@ -40,6 +40,7 @@ const customWrapperProps = [
 	'isClickable',
 	'hasIcon',
 	'hasSideButton',
+	'iconOnly',
 ];
 
 const Wrapper = styled.div.withConfig({
@@ -62,9 +63,10 @@ const Wrapper = styled.div.withConfig({
 
 	${marginProps}
 
-	padding: 0 ${p => p.theme.globals.spacing.xs};
+	padding: 0 ${p => (p.iconOnly ? 0 : p.theme.globals.spacing.xs)};
 	${p =>
 		p.hasIcon &&
+		!p.iconOnly &&
 		`
 			padding-left: ${iconSpacing};
 		`}
@@ -90,7 +92,7 @@ const Wrapper = styled.div.withConfig({
 		`
 			border-top-right-radius: 0;
 			border-bottom-right-radius: 0;
-			border-right: ${borderValue(p.theme)};
+			border-right: ${p.iconOnly ? 0 : borderValue(p.theme)};
 		`}
 
 	${p =>
@@ -311,6 +313,7 @@ const Pill = forwardRef((props, ref) => {
 				hasIcon={Boolean(token)}
 				hasSideButton={hasSideButton}
 				background={background}
+				iconOnly={iconOnly}
 			>
 				{isClickable && (
 					<>
@@ -318,11 +321,14 @@ const Pill = forwardRef((props, ref) => {
 						<FocusRing />
 					</>
 				)}
-				{token && (
-					<Box position="absolute" top left>
-						{token}
-					</Box>
-				)}
+				{token &&
+					(iconOnly ? (
+						token
+					) : (
+						<Box position="absolute" top left>
+							{token}
+						</Box>
+					))}
 				{iconOnly ? (
 					<VisuallyHidden>{children}</VisuallyHidden>
 				) : (


### PR DESCRIPTION
- Sets children as required for `Pill`s
- Adds visually hidden label for icon-only `Pill`s

<img width="149" alt="Screenshot 2021-11-26 at 12 00 39" src="https://user-images.githubusercontent.com/41924354/143577949-a11e9c3e-c4ce-4506-9db5-2db41092c83c.png">
