### PR TITLE
feat: add radiobutton adjustments for ie11, #11298

### DIFF
--- a/src/RadioButton/index.js
+++ b/src/RadioButton/index.js
@@ -33,7 +33,9 @@ const MockBox = styled.span.withConfig({
 	justify-content: center;
 
 	width: ${pxToEm(16)};
+	min-width: ${pxToEm(16)};
 	height: ${pxToEm(16)};
+	min-height: ${pxToEm(16)};
 
 	font-size: ${p => (p.scale === 'auto' ? '1em' : pxToRem(20 * p.scale))};
 


### PR DESCRIPTION
fixes #11298

Additionally adds min-width and min-height properties to prevent radiobuttons from collapsing on ie11