### PR TITLE
feat: localisation time component, #185

### DIFF
--- a/src/Time/README.stories.mdx
+++ b/src/Time/README.stories.mdx
@@ -46,6 +46,19 @@ The component auto-updates to keep the time accurate without requiring a page re
 	<Time dateTime="1981-05-12" />
 </Canvas>
 
+### DE locale
+<Canvas>
+	<Time dateTime="2019-08-24T13:30:00Z" systemTime="2019-08-29T12:00:00Z" locale="de-DE" />
+</Canvas>
+
+<Canvas>
+	<Time dateTime="2019-01-24T13:30:00Z" systemTime="2019-08-29T12:00:00Z" locale="de-DE"/>
+</Canvas>
+
+<Canvas>
+	<Time dateTime="1981-05-12"  locale="de-DE" />
+</Canvas>
+
 ## Invalid examples
 
 <Canvas>

--- a/src/Time/getDateString.js
+++ b/src/Time/getDateString.js
@@ -16,7 +16,7 @@ function date(d) {
 
 function getDateString({
 	dateTime,
-	locale = 'en-GB',
+	locale = navigator.language,
 	systemOffset = 0,
 	readoutFunctions = {},
 }) {

--- a/src/Time/getDateString.js
+++ b/src/Time/getDateString.js
@@ -19,8 +19,6 @@ function getDateString({
 	locale = 'en-GB',
 	systemOffset = 0,
 	readoutFunctions = {},
-	getMinReadoutLabel,
-	getSecReadoutLabel,
 }) {
 	// Default hourCycle value
 	let hourCycle = 'h24';
@@ -33,13 +31,9 @@ function getDateString({
 	// Set default readout functions
 	const {
 		secondsAgoReadout = count =>
-			getSecReadoutLabel
-				? getSecReadoutLabel(count)
-				: `${count} second${count > 1 ? 's' : ''} ago`,
+			`${count} second${count > 1 ? 's' : ''} ago`,
 		minutesAgoReadout = count =>
-			getMinReadoutLabel
-				? getMinReadoutLabel(count)
-				: `${count} minute${count > 1 ? 's' : ''} ago`,
+			`${count} minute${count > 1 ? 's' : ''} ago`,
 	} = readoutFunctions;
 
 	// Define the offset, how old is this...

--- a/src/Time/getDateString.js
+++ b/src/Time/getDateString.js
@@ -16,11 +16,19 @@ function date(d) {
 
 function getDateString({
 	dateTime,
-	locale,
+	locale = 'en-GB',
 	systemOffset = 0,
 	readoutFunctions = {},
 }) {
+	let hourCycle = 'h24';
+	// Set of languages for which we want to display AM / PM
+	const hourCycle12Languages = ['en-GB', 'en-US', 'es-ES'];
+	if (hourCycle12Languages.includes(locale)) {
+		hourCycle = 'h12';
+	}
+
 	// Set default readout functions
+	// TODO: add localisation
 	const {
 		secondsAgoReadout = count =>
 			`${count} second${count > 1 ? 's' : ''} ago`,
@@ -61,12 +69,12 @@ function getDateString({
 		const mins = parseInt(offset / ONE_MINUTE);
 		dateString = minutesAgoReadout(mins);
 	}
-	// Occcured today...
+	// Occured today...
 	else if (offset < ms_today) {
 		// Number of ms until end of the day...
 		delay = ONE_DAY - ms_today;
 		dateString = new Intl.DateTimeFormat(locale, {
-			hourCycle: 'h12',
+			hourCycle,
 			hour: 'numeric',
 			minute: 'numeric',
 		}).format(time);
@@ -78,7 +86,7 @@ function getDateString({
 		// Get day
 		dateString = new Intl.DateTimeFormat(locale, {
 			weekday: 'short',
-			hourCycle: 'h12',
+			hourCycle,
 			hour: 'numeric',
 		}).format(time);
 	} else if (time.getYear() === systemtime.getYear()) {

--- a/src/Time/getDateString.js
+++ b/src/Time/getDateString.js
@@ -19,21 +19,27 @@ function getDateString({
 	locale = 'en-GB',
 	systemOffset = 0,
 	readoutFunctions = {},
+	getMinReadoutLabel,
+	getSecReadoutLabel,
 }) {
+	// Default hourCycle value
 	let hourCycle = 'h24';
-	// Set of languages for which we want to display AM / PM
 	const hourCycle12Languages = ['en-GB', 'en-US', 'es-ES'];
 	if (hourCycle12Languages.includes(locale)) {
+		// Set hourCycle to 12 for languages for which we want to display AM / PM
 		hourCycle = 'h12';
 	}
 
 	// Set default readout functions
-	// TODO: add localisation
 	const {
 		secondsAgoReadout = count =>
-			`${count} second${count > 1 ? 's' : ''} ago`,
+			getSecReadoutLabel
+				? getSecReadoutLabel(count)
+				: `${count} second${count > 1 ? 's' : ''} ago`,
 		minutesAgoReadout = count =>
-			`${count} minute${count > 1 ? 's' : ''} ago`,
+			getMinReadoutLabel
+				? getMinReadoutLabel(count)
+				: `${count} minute${count > 1 ? 's' : ''} ago`,
 	} = readoutFunctions;
 
 	// Define the offset, how old is this...

--- a/src/Time/index.js
+++ b/src/Time/index.js
@@ -9,15 +9,7 @@ function useForceUpdate() {
 	return forceUpdate;
 }
 
-function Time({
-	dateTime,
-	systemTime,
-	readoutFunctions,
-	locale,
-	getMinReadoutLabel,
-	getSecReadoutLabel,
-	...otherProps
-}) {
+function Time({dateTime, systemTime, readoutFunctions, locale, ...otherProps}) {
 	const forceUpdate = useForceUpdate();
 
 	// Offset system time with local time...
@@ -31,8 +23,6 @@ function Time({
 		dateTime,
 		locale,
 		systemOffset: systemOffset.current,
-		getMinReadoutLabel,
-		getSecReadoutLabel,
 	});
 
 	// Set the datestring
@@ -81,10 +71,6 @@ Time.propTypes = {
 		secondsAgoReadout: PropTypes.func,
 		minutesAgoReadout: PropTypes.func,
 	}),
-	/** Customise the minutes label, i.e. for localisation */
-	getMinReadoutLabel: PropTypes.func,
-	/** Customise the seconds label, i.e. for localisation */
-	getSecReadoutLabel: PropTypes.func,
 };
 
 export default Time;

--- a/src/Time/index.js
+++ b/src/Time/index.js
@@ -9,7 +9,15 @@ function useForceUpdate() {
 	return forceUpdate;
 }
 
-function Time({dateTime, systemTime, readoutFunctions, locale, ...otherProps}) {
+function Time({
+	dateTime,
+	systemTime,
+	readoutFunctions,
+	locale,
+	getMinReadoutLabel,
+	getSecReadoutLabel,
+	...otherProps
+}) {
 	const forceUpdate = useForceUpdate();
 
 	// Offset system time with local time...
@@ -23,6 +31,8 @@ function Time({dateTime, systemTime, readoutFunctions, locale, ...otherProps}) {
 		dateTime,
 		locale,
 		systemOffset: systemOffset.current,
+		getMinReadoutLabel,
+		getSecReadoutLabel,
 	});
 
 	// Set the datestring
@@ -71,6 +81,10 @@ Time.propTypes = {
 		secondsAgoReadout: PropTypes.func,
 		minutesAgoReadout: PropTypes.func,
 	}),
+	/** Customise the minutes label, i.e. for localisation */
+	getMinReadoutLabel: PropTypes.func,
+	/** Customise the seconds label, i.e. for localisation */
+	getSecReadoutLabel: PropTypes.func,
 };
 
 export default Time;


### PR DESCRIPTION
fixes: #185 

- sets default locale to `en-GB`
- sets default `hourCycle` to `24` and only sets `hourCycle` to `12` for locales where we want to display `AM` / `PM`

Screenshot:
<img width="1294" alt="Screenshot 2022-03-03 at 12 32 07 1" src="https://user-images.githubusercontent.com/41924354/156565343-470c61af-46a6-4050-b6c9-4f0878b54a9a.png">
