### PR TITLE
fix: fix duplicate loader for iconright, #noissue

### DIFF
--- a/src/Button/README.stories.mdx
+++ b/src/Button/README.stories.mdx
@@ -73,6 +73,9 @@ Basic button types and sizes:
 		<Button  iconRight icon="arrow-right" isActive size="medium">
 			Let's go
 		</Button>
+		<Button iconRight="arrow-right" isActive size="medium">
+			Let's go again
+		</Button>
 	</InlineList>
 </Canvas>
 
@@ -101,6 +104,9 @@ Disabled:
 		<Button isDisabled iconRight icon="arrow-right" isActive size="medium">
 			Let's go
 		</Button>
+		<Button isDisabled iconRight="arrow-right" isActive size="medium">
+			Let's go again
+		</Button>
 	</InlineList>
 </Canvas>
 
@@ -128,6 +134,9 @@ Loading:
 		</Button>
 		<Button isLoading iconRight icon="arrow-right" isActive size="medium">
 			Let's go
+		</Button>
+		<Button isLoading iconRight="arrow-right" isActive size="medium">
+			Let's go again
 		</Button>
 	</InlineList>
 </Canvas>

--- a/src/Button/index.js
+++ b/src/Button/index.js
@@ -347,7 +347,9 @@ const Button = forwardRef((props, ref) => {
 							{isLoading && (
 								<VisuallyHidden>{loadingLabel}</VisuallyHidden>
 							)}
-							{!icon && isLoading && <SpinnerDot />}
+							{!icon && !hasSeparateRightIcon && isLoading && (
+								<SpinnerDot />
+							)}
 						</>
 					))}
 


### PR DESCRIPTION
For the case when `iconRight` was added as a string and not as a boolean, we were displaying two loading spinners when the button was in the loading state.
This PR fixes that.


https://user-images.githubusercontent.com/41924354/166896581-551d59cc-8a98-4fce-ae56-63e5643ac228.mov

